### PR TITLE
Add INFO logging to greet CLI and verify logs in tests

### DIFF
--- a/src/app/greet.py
+++ b/src/app/greet.py
@@ -1,4 +1,7 @@
 import argparse
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def greet(name: str) -> str:
@@ -6,6 +9,7 @@ def greet(name: str) -> str:
 
 
 def main() -> None:
+    logger.info("greet CLI started")
     parser = argparse.ArgumentParser(
         description="Print a GitHub learning greeting."
     )
@@ -17,7 +21,10 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    print(greet(args.name))
+    logger.info("Input name: %s", args.name)
+    message = greet(args.name)
+    logger.info("Output message: %s", message)
+    print(message)
 
 
 if __name__ == "__main__":

--- a/tests/test_greet.py
+++ b/tests/test_greet.py
@@ -19,3 +19,14 @@ def test_main_with_arg(monkeypatch, capsys):
     main()
     captured = capsys.readouterr()
     assert "Hello, Alice!" in captured.out
+
+
+def test_main_logs(monkeypatch, caplog):
+    monkeypatch.setattr(sys, "argv", ["prog", "Bob"])
+
+    with caplog.at_level("INFO"):
+        main()
+
+    assert "greet CLI started" in caplog.text
+    assert "Input name: Bob" in caplog.text
+    assert "Output message: Hello, Bob! Welcome to GitHub." in caplog.text


### PR DESCRIPTION
### Motivation
- Add observable logging to the CLI to aid debugging and to record input/output events when `main` runs.

### Description
- Import `logging` and create a module-level `logger` in `src/app/greet.py` and add `INFO` logs for startup, input name, and output message in `main`.
- Modify `main` to assign the greeting to `message` before printing and to log the `message` value.
- Add `test_main_logs` in `tests/test_greet.py` to assert the presence of the new log lines using `caplog`.

### Testing
- Ran the test suite including `test_greet`, `test_main_default`, `test_main_with_arg`, and the new `test_main_logs`, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2460af3948330a113c18c38c30534)